### PR TITLE
inventory.jade

### DIFF
--- a/StoreWebApp/views/inventory.jade
+++ b/StoreWebApp/views/inventory.jade
@@ -29,15 +29,18 @@ block content
         each item in item_array
           div.pure-u-1.pure-u-md-1-3.pure-u-lg-1-5
             div.item-box
-              a(href= "/item/" + item.id).pure-menu-link.item-link
-                div.pure-g
-                  div.pure-u-1
+              div.pure-g
+                div.pure-u-1
+                  a(href= "/item/" + item.id).pure-menu-link.item-link
                     img(src= base_url + item.img).pure-img
-                  div.pure-u-1
+                div.pure-u-1
+                  a(href= "/item/" + item.id).pure-menu-link.item-link
                     div.item-section= item.name
-                  div.pure-u-1-2
+                div.pure-u-1-2
+                  a(href= "/item/" + item.id).pure-menu-link.item-link
                     div.item-section= '$' + item.price
-                  div.pure-u-1-2
+                div.pure-u-1-2
+                  a(href= "/item/" + item.id).pure-menu-link.item-link
                     div.item-section.item-rating
                       - var rating = (item.rating) ? item.rating : 0;
                       - var rounded_rating = Math.round(rating*2)/2;


### PR DESCRIPTION
The nested A tag breaks the formatting for pure CSS grid view... moving the A tag in the inside of the pure grid helps to keep the formatting.